### PR TITLE
Sorted test tf console outputs

### DIFF
--- a/packages/cslam/src/test_tf.py
+++ b/packages/cslam/src/test_tf.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import curses
+
 import rospy
 import tf2_ros
 from geometry_msgs.msg import TransformStamped
@@ -13,7 +15,11 @@ from autolab_msgs.msg import \
 
 group = DTCommunicationGroup("/autolab/tf", AutolabTransform)
 shelf = set()
-printed = set()
+
+# terminal repainting
+stdscr = curses.initscr()
+curses.noecho()
+curses.cbreak()
 
 def cb(msg, _):
     shelf.add((msg.origin.name, msg.target.name))
@@ -27,14 +33,19 @@ def cb(msg, _):
     #
     # br.sendTransform(t)
 
-    to_print = shelf.difference(printed)
-    for edge in to_print:
-        print(edge)
-    printed.update(to_print)
+    # print sorted edges
+    for i, e in enumerate(sorted(shelf)):
+        stdscr.addstr(i, 0, str(e))
+    stdscr.refresh()
 
 
-print('Listening...')
-group.Subscriber(cb)
+try:
+    group.Subscriber(cb)
+finally:
+    curses.echo()
+    curses.nocbreak()
+    curses.endwin()
+
 
 # rospy.on_shutdown(group.shutdown)
 #

--- a/packages/cslam/src/test_tf.py
+++ b/packages/cslam/src/test_tf.py
@@ -35,7 +35,8 @@ def cb(msg, _):
 
     # print sorted edges
     for i, e in enumerate(sorted(shelf)):
-        stdscr.addstr(i, 0, str(e))
+        # pad some space to clear potentially longer previous outputs
+        stdscr.addstr(i, 0, str(e) + ' ' * 40)  
     stdscr.refresh()
 
 


### PR DESCRIPTION
Before, the tfs are printed once a new non-duplicate message is received. So the order of the WTs are not sorted, which makes it difficult to check if all WTs recognize the tags they're supposed to. This PR changed it such that the console is refreshed with sorted results.

---
### Console outputs with this PR
```
('/watchtower20/camera_optical_frame', 'tag/317')
('/watchtower20/camera_optical_frame', 'tag/370')
('/watchtower20/camera_optical_frame', 'tag/388')
('/watchtower21/camera_optical_frame', 'tag/302')
('/watchtower21/camera_optical_frame', 'tag/356')
('/watchtower21/camera_optical_frame', 'tag/397')
('/watchtower21/camera_optical_frame', 'tag/403')
('/watchtower22/camera_optical_frame', 'tag/301')
('/watchtower22/camera_optical_frame', 'tag/302')
('/watchtower22/camera_optical_frame', 'tag/347')
('/watchtower23/camera_optical_frame', 'tag/303')
('/watchtower23/camera_optical_frame', 'tag/304')
('/watchtower23/camera_optical_frame', 'tag/356')
('/watchtower24/camera_optical_frame', 'tag/302')
('/watchtower24/camera_optical_frame', 'tag/317')
('/watchtower24/camera_optical_frame', 'tag/397')
('/watchtower24/camera_optical_frame', 'tag/403')
('/watchtower25/camera_optical_frame', 'tag/313')
('/watchtower25/camera_optical_frame', 'tag/370')
('/watchtower28/camera_optical_frame', 'tag/342')
('/watchtower28/camera_optical_frame', 'tag/347')
('autobot04/footprint', 'autobot04/footprint')
('map', 'tag/301')
('map', 'tag/302')
('map', 'tag/303')
('map', 'tag/304')
('map', 'tag/313')
('map', 'tag/317')
('map', 'tag/342')
('map', 'tag/347')
('map', 'tag/356')
('map', 'tag/370')
('map', 'tag/388')
('map', 'tag/397')
('tag/403', 'autobot04/footprint')
('world', 'map')
```
---
### Previous console outputs
```
Listening...
('/watchtower22/camera_optical_frame', 'tag/301')
('/watchtower25/camera_optical_frame', 'tag/313')
('/watchtower22/camera_optical_frame', 'tag/302')
('/watchtower22/camera_optical_frame', 'tag/347')
('/watchtower25/camera_optical_frame', 'tag/370')
('/watchtower20/camera_optical_frame', 'tag/317')
('/watchtower20/camera_optical_frame', 'tag/388')
('/watchtower21/camera_optical_frame', 'tag/302')
('/watchtower21/camera_optical_frame', 'tag/356')
('/watchtower21/camera_optical_frame', 'tag/403')
('/watchtower24/camera_optical_frame', 'tag/302')
('/watchtower24/camera_optical_frame', 'tag/317')
('/watchtower24/camera_optical_frame', 'tag/397')
('/watchtower24/camera_optical_frame', 'tag/403')
('/watchtower28/camera_optical_frame', 'tag/342')
('/watchtower28/camera_optical_frame', 'tag/347')
('/watchtower23/camera_optical_frame', 'tag/356')
('autobot04/footprint', 'autobot04/footprint')
('world', 'map')
('map', 'tag/301')
('map', 'tag/302')
('map', 'tag/303')
('map', 'tag/304')
('map', 'tag/313')
('map', 'tag/317')
('map', 'tag/342')
('map', 'tag/347')
('map', 'tag/356')
('map', 'tag/370')
('map', 'tag/388')
('map', 'tag/397')
('/watchtower23/camera_optical_frame', 'tag/304')
('/watchtower20/camera_optical_frame', 'tag/370')
('/watchtower21/camera_optical_frame', 'tag/397')
('tag/403', 'autobot04/footprint')
('/watchtower23/camera_optical_frame', 'tag/303')
('/watchtower28/camera_optical_frame', 'tag/313')
```